### PR TITLE
added gvar for instadeath protection invuln time

### DIFF
--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -116,6 +116,13 @@ class ACE_Settings {
         typeName = "BOOL";
         value = 0;
     };
+    class GVAR(preventInstaDeathTime) {
+        category = CSTRING(Category_Medical);
+        displayName = CSTRING(MedicalSettings_preventInstaDeathTime_DisplayName);
+        description = CSTRING(MedicalSettings_preventInstaDeathTime_Description);
+        typeName = "SCALAR";
+        value = 5;
+    };
     class GVAR(enableRevive) {
         category = CSTRING(Category_Medical);
         displayName = CSTRING(ReviveSettings_enableRevive_DisplayName);

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -128,6 +128,12 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 0;
             };
+            class preventInstaDeathTime {
+                displayName = CSTRING(MedicalSettings_preventInstaDeathTime_DisplayName);
+                description = CSTRING(MedicalSettings_preventInstaDeathTime_Description);
+                typeName = "SCALAR";
+                defaultValue = 5;
+            };
             class bleedingCoefficient {
                 displayName = CSTRING(MedicalSettings_bleedingCoefficient_DisplayName);
                 description = CSTRING(MedicalSettings_bleedingCoefficient_Description);

--- a/addons/medical/functions/fnc_moduleMedicalSettings.sqf
+++ b/addons/medical/functions/fnc_moduleMedicalSettings.sqf
@@ -30,6 +30,7 @@ if !(_activated) exitWith {};
 [_logic, QGVAR(enableUnconsciousnessAI), "enableUnconsciousnessAI"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(remoteControlledAI), "remoteControlledAI"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(preventInstaDeath), "preventInstaDeath"] call EFUNC(common,readSettingFromModule);
+[_logic, QGVAR(preventInstaDeathTime), "preventInstaDeathTime"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(bleedingCoefficient), "bleedingCoefficient"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(painCoefficient), "painCoefficient"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(keepLocalSettingsSynced), "keepLocalSettingsSynced"] call EFUNC(common,readSettingFromModule);

--- a/addons/medical/functions/fnc_setUnconscious.sqf
+++ b/addons/medical/functions/fnc_setUnconscious.sqf
@@ -58,7 +58,7 @@ if ((_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) && (
 	_unit setVariable ["ACE_medical_allowDamage", false, true];
 	[{
         (_this select 0) setVariable ["ACE_medical_allowDamage", true, true];
-    }, [_unit], 5, 0] call EFUNC(common,waitAndExecute);
+    }, [_unit], _unit getVariable [QGVAR(preventInstaDeathTime), 5], 0] call EFUNC(common,waitAndExecute);
 };
 // if we have unconsciousness for AI disabled, we will kill the unit instead
 _isDead = false;


### PR DESCRIPTION
- add mission scripting access to the instant death protection invulnerability timer
- 5 sec sleep until damage re-enabled changed to unit getvariable ace_medical_preventInstaDeathTime, default 5
